### PR TITLE
Fix sigh renew password set through environment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,14 @@ pluginBundle {
     tags = ["ios", "fastlane"]
 }
 
+test {
+    useJUnitPlatform()
+}
+
+integrationTest {
+    useJUnitPlatform()
+}
+
 gradlePlugin {
     plugins {
         plugins {
@@ -49,6 +57,8 @@ cveHandler {
 }
 
 dependencies {
-    implementation 'com.wooga.gradle:gradle-commons:[1,2['
-    testImplementation 'com.wooga.gradle:gradle-commons-test:[1,2['
+    implementation 'com.wooga.gradle:gradle-commons:[1.5.1,2['
+    testImplementation 'org.spockframework:spock-junit4:2.1-groovy-2.5'
+    testImplementation 'org.spockframework:spock-core:2.1-groovy-2.5'
+    testImplementation 'com.wooga.gradle:gradle-commons-test:[1.9,2['
 }

--- a/src/integrationTest/groovy/wooga/gradle/fastlane/FastlaneIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/FastlaneIntegrationSpec.groovy
@@ -16,6 +16,7 @@
 
 package wooga.gradle.fastlane
 
+import com.wooga.gradle.test.BatchmodeWrapper
 
 import java.nio.file.Paths
 
@@ -25,14 +26,9 @@ abstract class FastlaneIntegrationSpec extends IntegrationSpec {
     File fastlaneMockPath
 
     def setupFastlaneMock() {
-        fastlaneMockPath = File.createTempDir("fastlane", "mock")
-        fastlaneMock = createFile("fastlane", fastlaneMockPath)
-        fastlaneMock.executable = true
-        fastlaneMock << """
-            #!/usr/bin/env bash
-            echo \$@
-            env
-        """.stripIndent()
+        fastlaneMock = new BatchmodeWrapper("fastlane").withEnvironment(true).toTempFile()
+        fastlaneMockPath = fastlaneMock.parentFile
+
     }
 
     def setup() {
@@ -42,8 +38,6 @@ abstract class FastlaneIntegrationSpec extends IntegrationSpec {
               ${applyPlugin(FastlanePlugin)}
            """.stripIndent()
     }
-
-
 
     // TODO: Replace with newer test API. subStr is an object since we invoke this for any types then discard
     Object substitutePath(Object expectedValue, Object value, String typeName) {


### PR DESCRIPTION
## Description

This is a small patch which only involves to bump `com.wooga.gradle:gradle-commons` to min version `1.5.1`. We need the functionality of the `ExecSpec`/`ProcessExecutor` to handle environment values correctly. The latest version had a bug and was not pushing the values provided in the environment map to the executable.

I adjusted the tests to actually test the values being passed to the called process instead of checking the task properties only.

## Changes

* ![FIX] sigh renew password set through environment

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
