### PR TITLE
Improve Appstore Connect API key handling

### DIFF
--- a/src/main/groovy/wooga/gradle/fastlane/tasks/AbstractFastlaneTask.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/tasks/AbstractFastlaneTask.groovy
@@ -41,6 +41,10 @@ abstract class AbstractFastlaneTask extends DefaultTask implements FastLaneTaskS
                 environment['FASTLANE_PASSWORD'] = password.get()
             }
 
+            if (apiKey.isPresent()) {
+                environment["APP_STORE_CONNECT_API_KEY"] = apiKey.get()
+            }
+
             if (skip2faUpgrade.isPresent() && skip2faUpgrade.get()) {
                 environment["SPACESHIP_SKIP_2FA_UPGRADE"] = "1"
             }
@@ -71,7 +75,6 @@ abstract class AbstractFastlaneTask extends DefaultTask implements FastLaneTaskS
         addOptionalArgument(arguments, "--team_name", teamName)
         addOptionalArgument(arguments, "--app_identifier", appIdentifier)
         addOptionalArgument(arguments, "--api_key_path", apiKeyPath.getAsFile().map {it.path})
-        addOptionalArgument(arguments, "--api_key", apiKey)
     }
 
     protected static addFlag(List<String> arguments, String flagName, Provider<Boolean> flag) {


### PR DESCRIPTION
## Description

Instead of passing the string value for the argument `--api_key` to the cli pass it as environment variable `APP_STORE_CONNECT_API_KEY` analog to how we handle the `--password` argument so to not leak secret values in CI consoles etc.

## Changes

* ![IMPROVE] Appstore Connect API key handling

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
