### PR TITLE
Improve App Store Connect API key binding

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/fastlane/FastlanePluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/FastlanePluginIntegrationSpec.groovy
@@ -19,13 +19,18 @@ package wooga.gradle.fastlane
 import com.wooga.gradle.PlatformUtils
 import com.wooga.gradle.test.PropertyLocation
 import com.wooga.gradle.test.PropertyQueryTaskWriter
+import com.wooga.gradle.test.writers.PropertyGetterTaskWriter
+import com.wooga.gradle.test.writers.PropertySetterWriter
+import spock.lang.IgnoreIf
 import spock.lang.Requires
 import spock.lang.Unroll
 import wooga.gradle.fastlane.tasks.PilotUpload
 import wooga.gradle.fastlane.tasks.SighRenew
+import wooga.gradle.fastlane.tasks.SighRenewBatch
+import wooga.gradle.fastlane.tasks.SighRenewBatchIntegrationSpec
 
 import static com.wooga.gradle.PlatformUtils.escapedPath
-import static com.wooga.gradle.test.PropertyUtils.envNameFromProperty
+import static com.wooga.gradle.test.writers.PropertySetInvocation.*
 
 class FastlanePluginIntegrationSpec extends FastlaneIntegrationSpec {
 
@@ -36,161 +41,94 @@ class FastlanePluginIntegrationSpec extends FastlaneIntegrationSpec {
            """.stripIndent()
     }
 
-    @Unroll("extension property #property returns '#testValue' if #reason")
-    def "extension property returns value"() {
-
-        given: "a gradle.properties"
-        def propertiesFile = createFile("gradle.properties")
-
-        switch (location) {
-            case PropertyLocation.script:
-                buildFile << "${extensionName}.${invocation}"
-                break
-            case PropertyLocation.property:
-                propertiesFile << "${extensionName}.${property} = ${escapedValue}"
-                break
-            case PropertyLocation.environment:
-                environmentVariables.set(envNameFromProperty(extensionName, property), "${value}")
-                break
-            default:
-                break
-        }
-
-        and: "the test value with replace placeholders"
-        if (testValue instanceof String) {
-            testValue = testValue.replaceAll("#projectDir#", escapedPath(projectDir.path))
-        }
-
-        when: ""
-        def query = new PropertyQueryTaskWriter("${extensionName}.${property}")
-        query.write(buildFile)
-        def result = runTasksSuccessfully(query.taskName)
-
-        then:
-        if (type != _) {
-            testValue = substitutePath(testValue, testValue, type)
-        }
-        query.matches(result, testValue)
-
-        where:
-        property              | method                    | rawValue                      | expectedValue | type                    | location                     | additionalInfo
-        "username"            | _                         | "someUser1"                   | _             | _                       | PropertyLocation.environment | ""
-        "username"            | _                         | "someUser2"                   | _             | _                       | PropertyLocation.property    | ""
-        "username"            | _                         | "someUser3"                   | _             | "String"                | PropertyLocation.script      | ""
-        "username"            | _                         | "someUser4"                   | _             | "Provider<String>"      | PropertyLocation.script      | ""
-        "username"            | "username.set"            | "someUser5"                   | _             | "String"                | PropertyLocation.script      | ""
-        "username"            | "username.set"            | "someUser6"                   | _             | "Provider<String>"      | PropertyLocation.script      | ""
-        "username"            | "username"                | "someUser7"                   | _             | "String"                | PropertyLocation.script      | ""
-        "username"            | "username"                | "someUser8"                   | _             | "Provider<String>"      | PropertyLocation.script      | ""
-        "username"            | _                         | _                             | null          | _                       | PropertyLocation.none        | ""
-
-
-        "password"            | _                         | "somePassword1"               | _             | _                       | PropertyLocation.environment | ""
-        "password"            | _                         | "somePassword2"               | _             | _                       | PropertyLocation.property    | ""
-        "password"            | _                         | "somePassword3"               | _             | "String"                | PropertyLocation.script      | ""
-        "password"            | _                         | "somePassword4"               | _             | "Provider<String>"      | PropertyLocation.script      | ""
-        "password"            | "password.set"            | "somePassword5"               | _             | "String"                | PropertyLocation.script      | ""
-        "password"            | "password.set"            | "somePassword6"               | _             | "Provider<String>"      | PropertyLocation.script      | ""
-        "password"            | "password"                | "somePassword7"               | _             | "String"                | PropertyLocation.script      | ""
-        "password"            | "password"                | "somePassword8"               | _             | "Provider<String>"      | PropertyLocation.script      | ""
-        "password"            | _                         | _                             | null          | _                       | PropertyLocation.none        | ""
-
-        "apiKeyPath"          | _                         | osPath("/path/to/key1.json")  | _             | _                       | PropertyLocation.environment | ""
-        "apiKeyPath"          | _                         | osPath("/path/to/key2.json")  | _             | _                       | PropertyLocation.property    | ""
-        "apiKeyPath"          | _                         | osPath("/path/to/key3.json")  | _             | "File"                  | PropertyLocation.script      | ""
-        "apiKeyPath"          | _                         | osPath("/path/to/key4.json")  | _             | "Provider<RegularFile>" | PropertyLocation.script      | ""
-        "apiKeyPath"          | "apiKeyPath.set"          | osPath("/path/to/key5.json")  | _             | "File"                  | PropertyLocation.script      | ""
-        "apiKeyPath"          | "apiKeyPath.set"          | osPath("/path/to/key6.json")  | _             | "Provider<RegularFile>" | PropertyLocation.script      | ""
-        "apiKeyPath"          | "apiKeyPath"              | osPath("/path/to/key7.json")  | _             | "File"                  | PropertyLocation.script      | ""
-        "apiKeyPath"          | "apiKeyPath"              | osPath("/path/to/key8.json")  | _             | "Provider<RegularFile>" | PropertyLocation.script      | ""
-        "apiKeyPath"          | _                         | _                             | null          | _                       | PropertyLocation.none        | ""
-
-        "skip2faUpgrade"      | _                         | true                          | _             | _                       | PropertyLocation.environment | ""
-        "skip2faUpgrade"      | _                         | true                          | _             | _                       | PropertyLocation.property    | ""
-        "skip2faUpgrade"      | _                         | true                          | _             | "Boolean"               | PropertyLocation.script      | ""
-        "skip2faUpgrade"      | _                         | true                          | _             | "Provider<Boolean>"     | PropertyLocation.script      | ""
-        "skip2faUpgrade"      | "skip2faUpgrade.set"      | true                          | _             | "Boolean"               | PropertyLocation.script      | ""
-        "skip2faUpgrade"      | "skip2faUpgrade.set"      | true                          | _             | "Provider<Boolean>"     | PropertyLocation.script      | ""
-        "skip2faUpgrade"      | "skip2faUpgrade"          | true                          | _             | "Boolean"               | PropertyLocation.script      | ""
-        "skip2faUpgrade"      | "skip2faUpgrade"          | true                          | _             | "Provider<Boolean>"     | PropertyLocation.script      | ""
-        "skip2faUpgrade"      | _                         | _                             | false         | _                       | PropertyLocation.none        | ""
-
-        extensionName = "fastlane"
-        value = (type != _) ? wrapValueBasedOnType(rawValue, type) : rawValue
-        providedValue = (location == PropertyLocation.script) ? type : value
-        testValue = (expectedValue == _) ? rawValue : expectedValue
-        reason = location.reason() + ((location == PropertyLocation.none) ? "" : "  with '$providedValue' ") + additionalInfo
-        escapedValue = (value instanceof String) ? escapedPath(value) : value
-        invocation = (method != _) ? "${method}(${escapedValue})" : "${property} = ${escapedValue}"
-    }
-
-    //TODO: These test should be able to run on all platforms but some path comparisons are quite tricky to test without some adjustments
+    @Unroll()
+    @IgnoreIf(value = { os.windows && data.property == "apiKeyPath" }, reason = "file based tests are not really working on windows")
+    @IgnoreIf(value = { os.windows && data.property == "executableDirectory" }, reason = "file based tests are not really working on windows")
+    @IgnoreIf(value = { os.windows && data.property == "executable" }, reason = "file based tests are not really working on windows")
     @Requires({ PlatformUtils.mac })
-    @Unroll("extension property #property returns '#testValue' if #reason")
-    def "extension property returns value2"() {
-
-        given: "a gradle.properties"
-        def propertiesFile = createFile("gradle.properties")
-
-        switch (location) {
-            case PropertyLocation.script:
-                buildFile << "${extensionName}.${invocation}"
-                break
-            case PropertyLocation.property:
-                propertiesFile << "${extensionName}.${property} = ${escapedValue}"
-                break
-            case PropertyLocation.environment:
-                environmentVariables.set(envNameFromProperty(extensionName, property), "${value}")
-                break
-            default:
-                break
-        }
-
-        and: "the test value with replace placeholders"
-        if (testValue instanceof String) {
-            testValue = testValue.replaceAll("#projectDir#", escapedPath(projectDir.path))
-        }
-
-        when: ""
-        def query = new PropertyQueryTaskWriter("${extensionName}.${property}")
-        query.write(buildFile)
-        def result = runTasksSuccessfully(query.taskName)
-
-        then:
-        if (type != _) {
-            testValue = substitutePath(testValue, testValue, type)
-        }
-        query.matches(result, testValue)
+    def "extension property #property of type #type sets #rawValue when #location"() {
+        expect:
+        runPropertyQuery(get, set).matches(rawValue)
 
         where:
-        property              | method                    | rawValue                      | expectedValue | type                    | location                     | additionalInfo
-        "executableName"      | _                         | "fastlane_2"                  | _             | _                       | PropertyLocation.environment | ""
-        "executableName"      | _                         | "fastlane_3"                  | _             | _                       | PropertyLocation.property    | ""
-        "executableName"      | "executableName.set"      | "fastlane_3"                  | _             | "String"                | PropertyLocation.script      | ""
-        "executableName"      | "executableName.set"      | "fastlane_4"                  | _             | "Provider<String>"      | PropertyLocation.script      | ""
-        "executableName"      | "setExecutableName"       | "fastlane_5"                  | _             | "String"                | PropertyLocation.script      | ""
-        "executableName"      | "setExecutableName"       | "fastlane_6"                  | _             | "Provider<String>"      | PropertyLocation.script      | ""
-        "executableName"      | _                         | "fastlane_6"                  | "fastlane"    | _                       | PropertyLocation.none        | ""
+        property              | setMethod   | rawValue                      | type                    | location
+        "username"            | _           | "someUser1"                   | _                       | PropertyLocation.environment
+        "username"            | _           | "someUser2"                   | _                       | PropertyLocation.property
+        "username"            | assignment  | "someUser3"                   | "String"                | PropertyLocation.script
+        "username"            | assignment  | "someUser4"                   | "Provider<String>"      | PropertyLocation.script
+        "username"            | providerSet | "someUser5"                   | "String"                | PropertyLocation.script
+        "username"            | providerSet | "someUser6"                   | "Provider<String>"      | PropertyLocation.script
+        "username"            | method      | "someUser7"                   | "String"                | PropertyLocation.script
+        "username"            | method      | "someUser8"                   | "Provider<String>"      | PropertyLocation.script
+        "username"            | _           | null                          | _                       | PropertyLocation.none
 
-        "executableDirectory" | _                         | osPath("/path/to/fastlane_2") | _             | _                       | PropertyLocation.environment | ""
-        "executableDirectory" | _                         | osPath("/path/to/fastlane_3") | _             | _                       | PropertyLocation.property    | ""
-        "executableDirectory" | "executableDirectory.set" | osPath("/path/to/fastlane_3") | _             | "File"                  | PropertyLocation.script      | ""
-        "executableDirectory" | "executableDirectory.set" | osPath("/path/to/fastlane_4") | _             | "Provider<Directory>"   | PropertyLocation.script      | ""
-        "executableDirectory" | "setExecutableDirectory"  | osPath("/path/to/fastlane_5") | _             | "File"                  | PropertyLocation.script      | ""
-        "executableDirectory" | "setExecutableDirectory"  | osPath("/path/to/fastlane_6") | _             | "Provider<Directory>"   | PropertyLocation.script      | ""
-        "executableDirectory" | _                         | osPath("/path/to/fastlane_6") | null          | _                       | PropertyLocation.none        | ""
+        "password"            | _           | "somePassword1"               | _                       | PropertyLocation.environment
+        "password"            | _           | "somePassword2"               | _                       | PropertyLocation.property
+        "password"            | assignment  | "somePassword3"               | "String"                | PropertyLocation.script
+        "password"            | assignment  | "somePassword4"               | "Provider<String>"      | PropertyLocation.script
+        "password"            | providerSet | "somePassword5"               | "String"                | PropertyLocation.script
+        "password"            | providerSet | "somePassword6"               | "Provider<String>"      | PropertyLocation.script
+        "password"            | method      | "somePassword7"               | "String"                | PropertyLocation.script
+        "password"            | method      | "somePassword8"               | "Provider<String>"      | PropertyLocation.script
+        "password"            | _           | null                          | _                       | PropertyLocation.none
 
-        "executable"          | "setExecutable"           | osPath("/path/to/fastlane_5") | _             | "String"                | PropertyLocation.script      | ""
-        "executable"          | "setExecutable"           | osPath("/path/to/fastlane_6") | _             | "Provider<String>"      | PropertyLocation.script      | ""
-        "executable"          | _                         | osPath("/path/to/fastlane_6") | "fastlane"    | _                       | PropertyLocation.none        | ""
+        "apiKeyPath"          | _           | osPath("/path/to/key1.json")  | _                       | PropertyLocation.environment
+        "apiKeyPath"          | _           | osPath("/path/to/key2.json")  | "File"                  | PropertyLocation.property
+        "apiKeyPath"          | assignment  | osPath("/path/to/key3.json")  | "File"                  | PropertyLocation.script
+        "apiKeyPath"          | assignment  | osPath("/path/to/key4.json")  | "Provider<RegularFile>" | PropertyLocation.script
+        "apiKeyPath"          | providerSet | osPath("/path/to/key5.json")  | "Provider<RegularFile>" | PropertyLocation.script
+        "apiKeyPath"          | providerSet | osPath("/path/to/key6.json")  | "File"                  | PropertyLocation.script
+        "apiKeyPath"          | method      | osPath("/path/to/key7.json")  | "Provider<RegularFile>" | PropertyLocation.script
+        "apiKeyPath"          | method      | null                          | _                       | PropertyLocation.none
+
+        "apiKey"              | _           | "someAPIKey1"                 | _                       | PropertyLocation.environment
+        "apiKey"              | _           | "someAPIKey2"                 | _                       | PropertyLocation.property
+        "apiKey"              | assignment  | "someAPIKey3"                 | "String"                | PropertyLocation.script
+        "apiKey"              | assignment  | "someAPIKey4"                 | "Provider<String>"      | PropertyLocation.script
+        "apiKey"              | providerSet | "someAPIKey5"                 | "String"                | PropertyLocation.script
+        "apiKey"              | providerSet | "someAPIKey6"                 | "Provider<String>"      | PropertyLocation.script
+        "apiKey"              | method      | "someAPIKey7"                 | "String"                | PropertyLocation.script
+        "apiKey"              | method      | "someAPIKey8"                 | "Provider<String>"      | PropertyLocation.script
+        "apiKey"              | _           | null                          | _                       | PropertyLocation.none
+
+        "skip2faUpgrade"      | _           | true                          | _                       | PropertyLocation.environment
+        "skip2faUpgrade"      | _           | false                         | _                       | PropertyLocation.property
+        "skip2faUpgrade"      | assignment  | true                          | "Boolean"               | PropertyLocation.script
+        "skip2faUpgrade"      | assignment  | false                         | "Provider<Boolean>"     | PropertyLocation.script
+        "skip2faUpgrade"      | providerSet | true                          | "Boolean"               | PropertyLocation.script
+        "skip2faUpgrade"      | providerSet | false                         | "Provider<Boolean>"     | PropertyLocation.script
+        "skip2faUpgrade"      | method      | true                          | "Boolean"               | PropertyLocation.script
+        "skip2faUpgrade"      | method      | false                         | "Provider<Boolean>"     | PropertyLocation.script
+        "skip2faUpgrade"      | _           | false                         | _                       | PropertyLocation.none
+
+        "executableName"      | _           | "fastlane_2"                  | _                       | PropertyLocation.environment
+        "executableName"      | _           | "fastlane_3"                  | _                       | PropertyLocation.property
+        "executableName"      | providerSet | "fastlane_3"                  | "String"                | PropertyLocation.script
+        "executableName"      | providerSet | "fastlane_4"                  | "Provider<String>"      | PropertyLocation.script
+        "executableName"      | assignment  | "fastlane_5"                  | "String"                | PropertyLocation.script
+        "executableName"      | assignment  | "fastlane_6"                  | "Provider<String>"      | PropertyLocation.script
+        "executableName"      | _           | "fastlane"                    | _                       | PropertyLocation.none
+
+        "executableDirectory" | _           | osPath("/path/to/fastlane_2") | _                       | PropertyLocation.environment
+        "executableDirectory" | _           | osPath("/path/to/fastlane_3") | _                       | PropertyLocation.property
+        "executableDirectory" | providerSet | osPath("/path/to/fastlane_3") | "File"                  | PropertyLocation.script
+        "executableDirectory" | providerSet | osPath("/path/to/fastlane_4") | "Provider<Directory>"   | PropertyLocation.script
+        "executableDirectory" | assignment  | osPath("/path/to/fastlane_5") | "File"                  | PropertyLocation.script
+        "executableDirectory" | assignment  | osPath("/path/to/fastlane_6") | "Provider<Directory>"   | PropertyLocation.script
+        "executableDirectory" | _           | null                          | _                       | PropertyLocation.none
+
+        "executable"          | assignment  | osPath("/path/to/fastlane_5") | "String"                | PropertyLocation.script
+        "executable"          | assignment  | osPath("/path/to/fastlane_6") | "Provider<String>"      | PropertyLocation.script
+        "executable"          | _           | "fastlane"                    | _                       | PropertyLocation.none
 
         extensionName = "fastlane"
-        value = (type != _) ? wrapValueBasedOnType(rawValue, type) : rawValue
-        providedValue = (location == PropertyLocation.script) ? type : value
-        testValue = (expectedValue == _) ? rawValue : expectedValue
-        reason = location.reason() + ((location == PropertyLocation.none) ? "" : "  with '$providedValue' ") + additionalInfo
-        escapedValue = (value instanceof String) ? escapedPath(value) : value
-        invocation = (method != _) ? "${method}(${escapedValue})" : "${property} = ${escapedValue}"
+        set = new PropertySetterWriter(extensionName, property)
+                .serialize(wrapValueFallback)
+                .set(rawValue, type)
+                .to(location)
+                .use(setMethod)
+
+        get = new PropertyGetterTaskWriter(set)
     }
 
     @Unroll("property #property of type #tasktype.simpleName is bound to property #extensionProperty of extension #extensionName")
@@ -216,24 +154,34 @@ class FastlanePluginIntegrationSpec extends FastlaneIntegrationSpec {
         query.matches(result, testValue)
 
         where:
-        property              | extensionProperty     | tasktype    | rawValue                     | expectedValue | type      | useProviderApi
-        "username"            | "username"            | SighRenew   | "userName1"                  | _             | "String"  | true
-        "username"            | "username"            | PilotUpload | "userName2"                  | _             | "String"  | true
+        property              | extensionProperty     | tasktype       | rawValue                     | expectedValue | type      | useProviderApi
+        "username"            | "username"            | SighRenew      | "userName1"                  | _             | "String"  | true
+        "username"            | "username"            | SighRenewBatch | "userName1"                  | _             | "String"  | true
+        "username"            | "username"            | PilotUpload    | "userName2"                  | _             | "String"  | true
 
-        "executableName"      | "executableName"      | SighRenew   | "fastlane_1"                 | _             | "String"  | true
-        "executableName"      | "executableName"      | PilotUpload | "fastlane_1"                 | _             | "String"  | true
+        "executableName"      | "executableName"      | SighRenew      | "fastlane_1"                 | _             | "String"  | true
+        "executableName"      | "executableName"      | SighRenewBatch | "fastlane_1"                 | _             | "String"  | true
+        "executableName"      | "executableName"      | PilotUpload    | "fastlane_1"                 | _             | "String"  | true
 
-        "executableDirectory" | "executableDirectory" | SighRenew   | osPath("/path/to/")          | _             | "File"    | true
-        "executableDirectory" | "executableDirectory" | PilotUpload | osPath("/path/to/")          | _             | "File"    | true
+        "executableDirectory" | "executableDirectory" | SighRenew      | osPath("/path/to/")          | _             | "File"    | true
+        "executableDirectory" | "executableDirectory" | SighRenewBatch | osPath("/path/to/")          | _             | "File"    | true
+        "executableDirectory" | "executableDirectory" | PilotUpload    | osPath("/path/to/")          | _             | "File"    | true
 
-        "password"            | "password"            | SighRenew   | "password1"                  | _             | "String"  | true
-        "password"            | "password"            | PilotUpload | "password2"                  | _             | "String"  | true
+        "password"            | "password"            | SighRenew      | "password1"                  | _             | "String"  | true
+        "password"            | "password"            | SighRenewBatch | "password1"                  | _             | "String"  | true
+        "password"            | "password"            | PilotUpload    | "password2"                  | _             | "String"  | true
 
-        "apiKeyPath"          | "apiKeyPath"          | SighRenew   | osPath("/path/to/key1.json") | _             | "File"    | true
-        "apiKeyPath"          | "apiKeyPath"          | PilotUpload | osPath("/path/to/key2.json") | _             | "File"    | true
+        "apiKeyPath"          | "apiKeyPath"          | SighRenew      | osPath("/path/to/key1.json") | _             | "File"    | true
+        "apiKeyPath"          | "apiKeyPath"          | SighRenewBatch | osPath("/path/to/key2.json") | _             | "File"    | true
+        "apiKeyPath"          | "apiKeyPath"          | PilotUpload    | osPath("/path/to/key3.json") | _             | "File"    | true
 
-        "skip2faUpgrade"      | "skip2faUpgrade"      | SighRenew   | true                         | _             | "Boolean" | true
-        "skip2faUpgrade"      | "skip2faUpgrade"      | PilotUpload | true                         | _             | "Boolean" | true
+        "apiKey"              | "apiKey"              | SighRenew      | "someAPIKey"                 | _             | "String"  | true
+        "apiKey"              | "apiKey"              | SighRenewBatch | "someAPIKey"                 | _             | "String"  | true
+        "apiKey"              | "apiKey"              | PilotUpload    | "someAPIKey"                 | _             | "String"  | true
+
+        "skip2faUpgrade"      | "skip2faUpgrade"      | SighRenew      | true                         | _             | "Boolean" | true
+        "skip2faUpgrade"      | "skip2faUpgrade"      | SighRenewBatch | true                         | _             | "Boolean" | true
+        "skip2faUpgrade"      | "skip2faUpgrade"      | PilotUpload    | true                         | _             | "Boolean" | true
 
         extensionName = "fastlane"
         taskName = "fastlaneTask"

--- a/src/main/groovy/wooga/gradle/fastlane/FastlanePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/FastlanePlugin.groovy
@@ -47,6 +47,7 @@ class FastlanePlugin implements Plugin<Project> {
         extension.username.convention(USERNAME_LOOKUP.getStringValueProvider(project))
         extension.password.convention(PASSWORD_LOOKUP.getStringValueProvider(project))
         extension.apiKeyPath.convention(API_KEY_PATH_LOOKUP.getFileValueProvider(project))
+        extension.apiKey.convention(API_KEY_LOOKUP.getStringValueProvider(project))
         extension.skip2faUpgrade.convention(SKIP_2FA_UPGRADE.getBooleanValueProvider(project))
         extension.executableName.convention(EXECUTABLE_NAME.getStringValueProvider(project))
         extension.executableDirectory.convention(EXECUTABLE_DIRECTORY.getDirectoryValueProvider(project))
@@ -60,8 +61,11 @@ class FastlanePlugin implements Plugin<Project> {
                 task.executableName.convention(extension.executableName)
                 task.executableDirectory.convention(extension.executableDirectory)
                 task.apiKeyPath.convention(extension.apiKeyPath)
+                task.apiKey.convention(extension.apiKey)
                 task.logToStdout.convention(true)
                 task.skip2faUpgrade.convention(extension.skip2faUpgrade)
+                task.username.convention(extension.username)
+                task.password.convention(extension.password)
             }
         })
 
@@ -70,9 +74,6 @@ class FastlanePlugin implements Plugin<Project> {
             void execute(SighRenew task) {
                 task.group = FASTLANE_GROUP
                 task.description = "runs fastlane sigh renew"
-
-                task.username.convention(extension.username)
-                task.password.convention(extension.password)
             }
         })
 

--- a/src/main/groovy/wooga/gradle/fastlane/FastlanePluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/FastlanePluginConventions.groovy
@@ -25,7 +25,8 @@ class FastlanePluginConventions {
     static final PropertyLookup EXECUTABLE_DIRECTORY = new PropertyLookup("FASTLANE_EXECUTABLE_DIRECTORY", "fastlane.executableDirectory", null)
     static final PropertyLookup USERNAME_LOOKUP = new PropertyLookup("FASTLANE_USERNAME", "fastlane.username", null)
     static final PropertyLookup PASSWORD_LOOKUP = new PropertyLookup("FASTLANE_PASSWORD", "fastlane.password", null)
-    static final PropertyLookup API_KEY_PATH_LOOKUP = new PropertyLookup("FASTLANE_API_KEY_PATH", "fastlane.apiKeyPath", null)
+    static final PropertyLookup API_KEY_PATH_LOOKUP = new PropertyLookup(["FASTLANE_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"], "fastlane.apiKeyPath", null)
+    static final PropertyLookup API_KEY_LOOKUP = new PropertyLookup(["FASTLANE_API_KEY", "APP_STORE_CONNECT_API_KEY"], "fastlane.apiKey", null)
     static final PropertyLookup SKIP_2FA_UPGRADE = new PropertyLookup(["SPACESHIP_SKIP_2FA_UPGRADE", "FASTLANE_SKIP_2FA_UPGRADE"], "fastlane.skip2faUpgrade", null)
 }
 


### PR DESCRIPTION
## Description

I also now added a binding from the `fastlane` extension to the task types. So one can specify the api key for appstore connect via a environment variable or gradle property

## Changes

* ![IMPROVE] App Store Connect API key binding

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
